### PR TITLE
Fixed bug: Updated parse_gtdbtk.Snakefile

### DIFF
--- a/maginator/workflow/parse_gtdbtk.Snakefile
+++ b/maginator/workflow/parse_gtdbtk.Snakefile
@@ -64,7 +64,7 @@ rule repres_genes:
     conda:
         "envs/filter_gtdbtk.yaml"
     shell:
-        "mmseqs easy-linclust --min-seq-id {params.seq_id} -c {params.cov} --threads {threads} {input} {params.out_prefix} {params.tmp_dir}; rm -r {params.tmp_dir};"
+        "mmseqs easy-cluster --cov-mode 1 --min-seq-id {params.seq_id} -c {params.cov} --threads {threads} {input} {params.out_prefix} {params.tmp_dir}; rm -r {params.tmp_dir};"
 
 
 # Add gene clusters to GTDB-tk data


### PR DESCRIPTION
MAGinator had a bug because of the default mmseqs gene clustering mode used. Due to this bug, gene fragments from incomplete assemblies would end up as their own gene clusters. This would inflate the total number of gene clusters, with unforeseen downstream consequences for signature gene selection and abundance estimation.

We have fixed this bug by changing the mmseqs clustering mode to coverage mode 1, so gene fragments do not end up as separate clusters, but instead get merged with their full-length counterparts.

In addition, the mmseqs clustering workflow has been changed from easy-linclust to easy-cluster, because the latter is fast enough (20 minutes for a deep 500-sample metagenome data set), while easy-linclust employs a number of heuristics to improve speed at the cost of accuracy.